### PR TITLE
Avoid duplicate output filenames in public S3 bucket

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -74,7 +74,7 @@ for f in ${OUTPUT_FILES}; do
 	done
 
 	LEN_m2=$(expr $LEN - 2)        # $LEN - 2
-	LEN_m1=$(expr $LEN - 1))       # $LEN - 1
+	LEN_m1=$(expr $LEN - 1)        # $LEN - 1
 	S3BASE="$S3BASE-${PR_STR}.${tokens[$LEN_m2]}.${tokens[$LEN_m1]}"
     fi
 

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -48,7 +48,7 @@ sudo pip install --upgrade pip
 sudo pip install awscli
 
 # Copy "processed_data" to "cimr-d" bucket (public).
-# "PR-<n>" is inserted in the filename to avoid possible duplicate filenames.
+# "PR-<n>" is inserted in filenames to avoid possible duplicates.
 OUTPUT_FILES=$(find processed_data -type f)
 for f in ${OUTPUT_FILES}; do
     g=$(echo $f | cut -d'/' -f'2-')                # strip "processed_data/" from $f


### PR DESCRIPTION
The bash code is a little ugly because the PR number is not added at the end of filename. When more corner cases show up, I may rewrite it in Python instead.