### PR TITLE
Add a note due to address GitHub 512-KB size limit on main page

### DIFF
--- a/.circleci/txt2md.py
+++ b/.circleci/txt2md.py
@@ -71,4 +71,5 @@ with open(TXT_FILENAME) as file_in, open(MD_FILENAME, 'w') as file_out:
             date_str = f" (updated on *{s3_date}*)"
             size_str = ": " + s3_size
             file_out.write(md_name + size_str + date_str + '\n')
+
         prev_folders = s3_name.split('/')[0:-1]

--- a/.circleci/txt2md.py
+++ b/.circleci/txt2md.py
@@ -6,6 +6,7 @@ the parent folder(s) as separate items in output MD file.
 TXT_FILENAME = "processed/s3_list.txt"
 MD_FILENAME = "processed/README.md"
 
+
 def get_md_name(s3_name):
     """Returns the filename with leading bullet list MD format."""
 
@@ -19,10 +20,12 @@ def get_md_name(s3_name):
         bucket_url = "https://cimr-d.s3.amazonaws.com"
         return f"{list_prefix}[{file_basename}]({bucket_url}/{s3_name})"
 
+
 def create_folders(curr_folders, prev_folders):
-    """This function compares curr_folders with prev_folders,
-    and generates all folders that are not in prev_folders.
+    """Compare curr_folders with prev_folders, then generate all folders
+    that are not in prev_folders.
     """
+
     idx = 0
     end = min(len(curr_folders), len(prev_folders))
     while idx < end:
@@ -41,12 +44,16 @@ def create_folders(curr_folders, prev_folders):
 
 
 with open(TXT_FILENAME) as file_in, open(MD_FILENAME, 'w') as file_out:
+    file_out.write(
+        "*Note: If the list is cutoff at the bottom due to GitHub's 512KB-limit\n"
+        "on the main page, click [here](README.md) to see its full content.*\n\n"
+    )
     file_out.write("List of processed files (with links to AWS S3 bucket):\n")
     file_out.write("----\n")
 
     prev_folders = []
     for line_in in file_in:
-        tokens = line_in.split()
+        tokens = line_in.strip().split()
         s3_name = " ".join(tokens[4:])
         md_name = get_md_name(s3_name)
 
@@ -58,11 +65,10 @@ with open(TXT_FILENAME) as file_in, open(MD_FILENAME, 'w') as file_out:
         else:
             curr_folders = s3_name.split('/')[0:-1]
             create_folders(curr_folders, prev_folders)
-            # For a regular file, includes size and date fields too
+            # For a regular file, include size and date fields too
             s3_date = tokens[0] + " " + tokens[1]
             s3_size = tokens[2] + " " + tokens[3]
             date_str = f" (updated on *{s3_date}*)"
             size_str = ": " + s3_size
             file_out.write(md_name + size_str + date_str + '\n')
-
         prev_folders = s3_name.split('/')[0:-1]

--- a/processed/README.md
+++ b/processed/README.md
@@ -1,3 +1,6 @@
+*Note: If the list is cutoff at the bottom due to GitHub's 512KB-limit
+on the main page, click [here](README.md) to see its full content.*
+
 List of processed files (with links to AWS S3 bucket):
 ----
   * eqtl


### PR DESCRIPTION
I noticed that when `processed/README.md` grows larger than 512 KB, the bottom part of it will be cutoff when it is rendered as the main page:
https://github.com/greenelab/cimr-d/tree/master/processed

But it is rendered correctly when shown as the individual file:
https://github.com/greenelab/cimr-d/blob/master/processed/README.md

Many GitHub users are complaining it now, so maybe GitHub will fix it later. But for now, I'm adding a note at the beginning of `processed/README.md` to avoid complaint from cimr-d users.

I also tweaked `txt2md.py` a little bit.
